### PR TITLE
GC verify debugging

### DIFF
--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -485,7 +485,7 @@ void G1BarrierSetC2::post_barrier(GraphKit* kit,
         Node* mapped;
         if (SanitizeGC) {
           mapped = __ make_leaf_call(mapNewAddrToOriginalAddr_Type(), CAST_FROM_FN_PTR(address,
-            SanitizerGCMapper::mapNewAddrToOriginalAddr), "mapNewAddrToOriginalAddr", card_adr)->in(0);
+            SanitizerGCMapper::mapNewAddrToOriginalAddr), "mapNewAddrToOriginalAddr", card_adr)->in(0);//->lookup(3); SANITIZE TODO
         } else {
           mapped = card_adr;
         }

--- a/src/hotspot/share/gc/g1/customMapper.cpp
+++ b/src/hotspot/share/gc/g1/customMapper.cpp
@@ -3,6 +3,8 @@
 ptrdiff_t SanitizerGCMapper::movedRegionOffset = 0;
 const void* SanitizerGCMapper::movedRegionStart = nullptr;
 const void* SanitizerGCMapper::movedRegionEnd = nullptr;
+const void* SanitizerGCMapper::originalRegionStart = nullptr;
+const void* SanitizerGCMapper::originalRegionEnd = nullptr;
 
 // Since we can't use void* for pointer arithmetic, we need another pointer
 // type, whose base element size is the unit for movedRegionOffset. We must use
@@ -12,21 +14,32 @@ const void* SanitizerGCMapper::movedRegionEnd = nullptr;
 using byte_ptr = const char*;
 
 void SanitizerGCMapper::initializeMapping(const void* originalRegionStart,
-        const void* movedRegionStart, const void* movedRegionEnd) {
+        const void* originalRegionEnd, const void* movedRegionStart, const void* movedRegionEnd) {
     SanitizerGCMapper::movedRegionOffset =
             static_cast<byte_ptr>(originalRegionStart) -
             static_cast<byte_ptr>(movedRegionStart);
     SanitizerGCMapper::movedRegionStart = movedRegionStart;
     SanitizerGCMapper::movedRegionEnd = movedRegionEnd;
+    SanitizerGCMapper::originalRegionStart = originalRegionStart;
+    SanitizerGCMapper::originalRegionEnd = originalRegionEnd;
 }
 
 const void* SanitizerGCMapper::mapNewAddrToOriginalAddr(const void* newAddr) {
     if (movedRegionOffset != 0 &&
-            newAddr >= movedRegionStart && newAddr < movedRegionEnd) {
+            newAddr >= movedRegionStart && newAddr <= movedRegionEnd) { // TODO
         return static_cast<byte_ptr>(newAddr) + movedRegionOffset;
     }
 
     return newAddr;
+}
+
+const void* SanitizerGCMapper::mapOriginalAddrToNewAddr(const void* originalAddr) {
+    if (movedRegionOffset != 0 &&
+            originalAddr >= originalRegionStart && originalAddr <= originalRegionEnd) {
+        return static_cast<byte_ptr>(originalAddr) - movedRegionOffset;
+            }
+
+    return originalAddr;
 }
 
 void SanitizerGCMapper::testPrint(void* newAddr) {

--- a/src/hotspot/share/gc/g1/customMapper.hpp
+++ b/src/hotspot/share/gc/g1/customMapper.hpp
@@ -9,16 +9,25 @@ private:
     static ptrdiff_t movedRegionOffset;
     static const void* movedRegionStart;
     static const void* movedRegionEnd;
+    static const void* originalRegionStart;
+    static const void* originalRegionEnd;
 
 public:
     static void initializeMapping(const void* originalRegionStart,
-            const void* movedRegionStart, const void* movedRegionEnd);
+            const void* originalRegionEnd, const void* movedRegionStart, const void* movedRegionEnd);
     static const void* mapNewAddrToOriginalAddr(const void* newAddr);
+    static const void* mapOriginalAddrToNewAddr(const void *newAddr);
+
     static void testPrint(void* newAddr);
     template <typename T> static inline void remapAddress(T &addr) {
       if (SanitizeGC) {
         addr = (T) mapNewAddrToOriginalAddr(addr);
       }
+    }
+    template <typename T> static inline void reverseRemapAddress(T &addr) {
+        if (SanitizeGC) {
+            addr = (T) mapOriginalAddrToNewAddr(addr);
+        }
     }
 };
 

--- a/src/hotspot/share/gc/g1/customMapper.hpp
+++ b/src/hotspot/share/gc/g1/customMapper.hpp
@@ -6,13 +6,16 @@
 
 class SanitizerGCMapper {
 private:
+    // TODO, put the public variables back here
+
+public:
     static ptrdiff_t movedRegionOffset;
     static const void* movedRegionStart;
     static const void* movedRegionEnd;
     static const void* originalRegionStart;
     static const void* originalRegionEnd;
 
-public:
+
     static void initializeMapping(const void* originalRegionStart,
             const void* originalRegionEnd, const void* movedRegionStart, const void* movedRegionEnd);
     static const void* mapNewAddrToOriginalAddr(const void* newAddr);

--- a/src/hotspot/share/gc/g1/g1BiasedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.hpp
@@ -29,6 +29,7 @@
 #include "memory/memRegion.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/powerOfTwo.hpp"
+#include "customMapper.hpp"
 
 // Implements the common base functionality for arrays that contain provisions
 // for accessing its elements using a biased index.
@@ -129,6 +130,7 @@ public:
   // Return the element of the given array that covers the given word in the
   // heap. Assumes the index is valid.
   T get_by_address(HeapWord* value) const {
+    SanitizerGCMapper::remapAddress(value);
     idx_t biased_index = ((uintptr_t)value) >> this->shift_by();
     this->verify_biased_index(biased_index);
     return biased_base()[biased_index];

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkBitMap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkBitMap.inline.hpp
@@ -38,7 +38,13 @@ inline bool G1CMBitMap::iterate(G1CMBitMapClosure* cl, MemRegion mr) {
          "Given MemRegion from " PTR_FORMAT " to " PTR_FORMAT " not contained in heap area",
          p2i(mr.start()), p2i(mr.end()));
 
+  // TODO SANITIZE
+  // HeapWord* end = mr.end();
+  // SanitizerGCMapper::remapAddress(end);
   BitMap::idx_t const end_offset = addr_to_offset(mr.end());
+
+  // HeapWord* start = mr.start();
+  // SanitizerGCMapper::remapAddress(start);
   BitMap::idx_t offset = _bm.find_first_set_bit(addr_to_offset(mr.start()), end_offset);
 
   while (offset < end_offset) {

--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -76,7 +76,7 @@ void G1HeapRegion::move_this_region() {
   }
 
   HeapWord* new_end = new_bottom + GrainWords;
-  SanitizerGCMapper::initializeMapping(_bottom, new_bottom, new_end);
+  SanitizerGCMapper::initializeMapping(_bottom, _end, new_bottom, new_end);
   _bottom = new_bottom;
   _top = new_bottom;
   _end = new_end;

--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -82,6 +82,69 @@ void G1HeapRegion::move_this_region() {
   _end = new_end;
 }
 
+class PrintG1HeapRegionInfoClosure : public HeapRegionClosure {
+public:
+  bool do_heap_region(G1HeapRegion* hr) override {
+    uint index = hr->hrm_index();
+    HeapWord* bottom = hr->bottom();
+    HeapWord* top = hr->top();
+    HeapWord* end = hr->end();
+
+    printf("----------  %p  ----------\n", bottom);
+    printf("|    hrm_index:  %d       \n", index);
+    printf("|    current top:  %p     \n", top);
+    printf("| is young: %d, is eden: %d, is old: %d, is survivor: %d\n", hr->is_young(), hr->is_eden(), hr->is_old(), hr->is_survivor());
+    printf("----------  %p  ----------\n\n", end);
+    return false;
+  }
+};
+
+void printMemoryRegionMap() {
+  G1CollectedHeap *heap = G1CollectedHeap::heap();
+
+  const void * originalStart = SanitizerGCMapper::originalRegionStart;
+  const void * originalEnd   = SanitizerGCMapper::originalRegionEnd;
+  const void * movedStart = SanitizerGCMapper::movedRegionStart;
+  const void * movedEnd   = SanitizerGCMapper::movedRegionEnd;
+
+  HeapWord * firstRegionBottom = heap->region_at(0)->bottom();
+
+  if (reinterpret_cast<const char *>(originalStart) < reinterpret_cast<const char *>(firstRegionBottom)) {
+    printf("----------  %p  ----------\n", originalStart);
+    printf("|    MOVED original       \n");
+    printf("|    hrm_index:  %d       \n", heap->addr_to_region(originalStart));
+    printf("----------  %p  ----------\n\n", originalEnd);
+    printf("   ...\n\n");
+  }
+
+  if (reinterpret_cast<const char *>(movedStart) < reinterpret_cast<const char *>(firstRegionBottom)) {
+    printf("----------  %p  ----------\n", movedStart);
+    printf("|    MOVED new            \n");
+    printf("|    hrm_index:  %d       \n", heap->addr_to_region(movedStart));
+    printf("----------  %p  ----------\n\n", movedEnd);
+    printf("   ...\n\n");
+  }
+
+  PrintG1HeapRegionInfoClosure customClosure;
+  heap->heap_region_iterate(&customClosure);
+
+  if (reinterpret_cast<const char *>(originalStart) > reinterpret_cast<const char *>(firstRegionBottom)) {
+    printf("   ...\n\n");
+    printf("----------  %p  ----------\n", originalStart);
+    printf("|    MOVED original       \n");
+    printf("|    hrm_index:  %d       \n", heap->addr_to_region(originalStart));
+    printf("----------  %p  ----------\n\n", originalEnd);
+  }
+
+  if (reinterpret_cast<const char *>(movedStart) > reinterpret_cast<const char *>(firstRegionBottom)) {
+    printf("   ...\n\n");
+    printf("----------  %p  ----------\n", movedStart);
+    printf("|    MOVED new            \n");
+    printf("|    hrm_index:  %d       \n", heap->addr_to_region(movedStart));
+    printf("----------  %p  ----------\n\n", movedEnd);
+  }
+}
+
 size_t G1HeapRegion::max_region_size() {
   return HeapRegionBounds::max_size();
 }
@@ -624,6 +687,20 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
     bool failed() const {
       if (_from != _to && !_from->is_young() && _to->rem_set()->is_complete()) {
         const CardValue dirty = G1CardTable::dirty_card_val();
+
+        if (SanitizeGC) {
+          printf("  - !( %d || ( %d ? %d : (%d || %d) ) )\n", _to->rem_set()->contains_reference(this->_p), this->_containing_obj->is_objArray(), (_cv_field == dirty), (_cv_obj == dirty), (_cv_field == dirty));
+        }
+
+        bool condition = !(_to->rem_set()->contains_reference(this->_p) ||
+                 (this->_containing_obj->is_objArray() ?
+                  _cv_field == dirty :
+                  _cv_obj == dirty || _cv_field == dirty));
+
+        if (SanitizeGC && condition) {
+          printf("SANITIZE"); // breakpoint catcher
+        }
+
         return !(_to->rem_set()->contains_reference(this->_p) ||
                  (this->_containing_obj->is_objArray() ?
                   _cv_field == dirty :

--- a/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
@@ -115,7 +115,7 @@ inline bool G1HeapRegion::is_in_parsable_area(const void* const addr) const {
 }
 
 inline bool G1HeapRegion::is_in_parsable_area(const void* const addr, const void* const pb) {
-  return addr >= pb;
+  return addr >= pb || (addr >= SanitizerGCMapper::movedRegionStart && addr <= SanitizerGCMapper::movedRegionEnd);
 }
 
 inline bool G1HeapRegion::is_marked_in_bitmap(oop obj) const {

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -118,13 +118,13 @@ G1HeapRegion* HeapRegionManager::allocate_free_region(HeapRegionType type, uint 
 
   if (SanitizeGC) {
     // SANITIZER, printing of bottom, top and end
-    printf("index: %d, _bottom: %p, _top: %p, _end: %p\n", hr->hrm_index(), hr->bottom(), hr->top(), hr->end());
+    printf("REGION WITH INDEX: %d, _bottom: %p, _end: %p\n", hr->hrm_index(), hr->bottom(), hr->end());
 
     // SANITIZER, moving the first region to different address
     if (!wasFirstTaken) {
       hr->move_this_region();
-      printf("region with index %d was moved here:\n", hr->hrm_index());
-      printf("    index: %d, _bottom: %p, _top: %p, _end: %p\n", hr->hrm_index(), hr->bottom(), hr->top(), hr->end());
+      printf("    %d was moved here:\n", hr->hrm_index());
+      printf("    index: %d, _bottom: %p, _end: %p\n", hr->hrm_index(), hr->bottom(), hr->end());
 
       wasFirstTaken = true;
     }
@@ -716,19 +716,21 @@ void HeapRegionManager::verify() {
     num_committed++;
     G1HeapRegion* hr = _regions.get_by_index(i);
     guarantee(hr != nullptr, "invariant: i: %u", i);
-    guarantee(!prev_committed || hr->bottom() == prev_end,
+    HeapWord* hr_bottom = hr->bottom();
+    SanitizerGCMapper::remapAddress(hr_bottom);
+    guarantee(!prev_committed || hr_bottom == prev_end,
               "invariant i: %u " HR_FORMAT " prev_end: " PTR_FORMAT,
               i, HR_FORMAT_PARAMS(hr), p2i(prev_end));
     guarantee(hr->hrm_index() == i,
               "invariant: i: %u hrm_index(): %u", i, hr->hrm_index());
     // Asserts will fire if i is >= _length
-    HeapWord* addr = hr->bottom();
-    guarantee(addr_to_region(addr) == hr, "sanity");
+    guarantee(addr_to_region(hr_bottom) == hr, "sanity");
     // We cannot check whether the region is part of a particular set: at the time
     // this method may be called, we have only completed allocation of the regions,
     // but not put into a region set.
     prev_committed = true;
     prev_end = hr->end();
+    SanitizerGCMapper::remapAddress(prev_end);
   }
   for (uint i = _allocated_heapregions_length; i < reserved_length(); i++) {
     guarantee(_regions.get_by_index(i) == nullptr, "invariant i: %u", i);

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -246,6 +246,7 @@ public:
   }
 
   bool do_heap_region(G1HeapRegion* r) {
+    // TODO SANITIZE
     guarantee(!r->has_index_in_opt_cset(), "Region %u still has opt collection set index %u", r->hrm_index(), r->index_in_opt_cset());
     guarantee(!r->is_young() || r->rem_set()->is_complete(), "Remembered set for Young region %u must be complete, is %s", r->hrm_index(), r->rem_set()->get_state_str());
     // Humongous and old regions regions might be of any state, so can't check here.

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -212,13 +212,21 @@ void CardTable::clear_MemRegion(MemRegion mr) {
   // Be conservative: only clean cards entirely contained within the
   // region.
   CardValue* cur;
-  if (mr.start() == _whole_heap.start()) {
-    cur = byte_for(mr.start());
+
+  HeapWord* start = mr.start();
+  SanitizerGCMapper::remapAddress(start);
+
+  if (start == _whole_heap.start()) {
+    cur = byte_for(start);
   } else {
-    assert(mr.start() > _whole_heap.start(), "mr is not covered.");
-    cur = byte_after(mr.start() - 1);
+    assert(start > _whole_heap.start(), "mr is not covered.");
+    cur = byte_after(start - 1);
   }
-  CardValue* last = byte_after(mr.last());
+
+  HeapWord* mr_last = mr.last();
+  SanitizerGCMapper::remapAddress(mr_last);
+
+  CardValue* last = byte_after(mr_last);
   memset(cur, clean_card, pointer_delta(last, cur, sizeof(CardValue)));
 }
 

--- a/src/hotspot/share/gc/shared/markBitMap.cpp
+++ b/src/hotspot/share/gc/shared/markBitMap.cpp
@@ -51,6 +51,7 @@ void MarkBitMap::do_clear(MemRegion mr, bool large) {
          "Given range from " PTR_FORMAT " to " PTR_FORMAT " is completely outside the heap",
          p2i(mr.start()), p2i(mr.end()));
   // convert address range into offset range
+  // TODO SANITIZE, maybe needs remapping
   size_t beg = addr_to_offset(intersection.start());
   size_t end = addr_to_offset(intersection.end());
   if (large) {

--- a/src/hotspot/share/gc/shared/markBitMap.hpp
+++ b/src/hotspot/share/gc/shared/markBitMap.hpp
@@ -48,7 +48,7 @@ protected:
   }
   // Convert from address to bit offset.
   size_t addr_to_offset(const HeapWord* addr) const {
-    SanitizerGCMapper::remapAddress(addr);
+    // SanitizerGCMapper::remapAddress(addr);
     return pointer_delta(addr, _covered.start()) >> _shifter;
   }
 

--- a/src/hotspot/share/gc/shared/markBitMap.inline.hpp
+++ b/src/hotspot/share/gc/shared/markBitMap.inline.hpp
@@ -33,14 +33,19 @@
 #include "utilities/align.hpp"
 #include "utilities/bitMap.inline.hpp"
 
-inline HeapWord* MarkBitMap::get_next_marked_addr(const HeapWord* const addr,
-                                                  HeapWord* const limit) const {
+inline HeapWord* MarkBitMap::get_next_marked_addr(const HeapWord* addr,
+                                                  HeapWord* limit) const {
   assert(limit != nullptr, "limit must not be null");
+  SanitizerGCMapper::remapAddress(addr);
+  SanitizerGCMapper::remapAddress(limit);
   // Round addr up to a possible object boundary to be safe.
   size_t const addr_offset = addr_to_offset(align_up(addr, HeapWordSize << _shifter));
   size_t const limit_offset = addr_to_offset(limit);
   size_t const nextOffset = _bm.find_first_set_bit(addr_offset, limit_offset);
-  return offset_to_addr(nextOffset);
+
+  HeapWord* next_addr = offset_to_addr(nextOffset);
+  SanitizerGCMapper::reverseRemapAddress(next_addr);
+  return next_addr;
 }
 
 inline void MarkBitMap::mark(HeapWord* addr) {
@@ -54,11 +59,13 @@ inline void MarkBitMap::mark(oop obj) {
 
 inline void MarkBitMap::clear(HeapWord* addr) {
   check_mark(addr);
+  SanitizerGCMapper::remapAddress(addr);
   _bm.clear_bit(addr_to_offset(addr));
 }
 
 inline bool MarkBitMap::par_mark(HeapWord* addr) {
   check_mark(addr);
+  SanitizerGCMapper::remapAddress(addr);
   return _bm.par_set_bit(addr_to_offset(addr));
 }
 

--- a/src/hotspot/share/memory/memRegion.cpp
+++ b/src/hotspot/share/memory/memRegion.cpp
@@ -26,6 +26,9 @@
 #include "memory/allocation.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/memRegion.hpp"
+
+#include <gc/g1/customMapper.hpp>
+
 #include "runtime/globals.hpp"
 
 // A very simple data structure representing a contiguous word-aligned
@@ -33,8 +36,18 @@
 
 MemRegion MemRegion::intersection(const MemRegion mr2) const {
   MemRegion res;
-  HeapWord* res_start = MAX2(start(), mr2.start());
-  HeapWord* res_end   = MIN2(end(),   mr2.end());
+
+  HeapWord* this_start = start();
+  HeapWord* mr2_start = mr2.start();
+  HeapWord* this_end = end();
+  HeapWord* mr2_end = mr2.end();
+  SanitizerGCMapper::remapAddress(this_start);
+  SanitizerGCMapper::remapAddress(mr2_start);
+  SanitizerGCMapper::remapAddress(this_end);
+  SanitizerGCMapper::remapAddress(mr2_end);
+
+  HeapWord* res_start = MAX2(this_start, mr2_start);
+  HeapWord* res_end   = MIN2(this_end,   mr2_end);
   if (res_start < res_end) {
     res.set_start(res_start);
     res.set_end(res_end);


### PR DESCRIPTION
Fixed a bug related to G1HeapRegion's parsable area and added the printMemoryRegionMap() function for debugging and other debugging prints in G1HeapRegion.cpp.